### PR TITLE
Add ostruct dependency for Ruby 4.0.0 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-musl)
       racc (~> 1.4)
+    ostruct (0.6.3)
     prism (1.9.0)
     pry (0.16.0)
       coderay (~> 1.1)
@@ -136,6 +137,7 @@ DEPENDENCIES
   drb
   logger
   mutex_m
+  ostruct
   pry-byebug
   rack-security-middleware!
   rack-test (~> 1.0)
@@ -173,6 +175,7 @@ CHECKSUMS
   nokogiri (1.19.2-x86_64-darwin) sha256=7d9af11fda72dfaa2961d8c4d5380ca0b51bc389dc5f8d4b859b9644f195e7a4
   nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
   nokogiri (1.19.2-x86_64-linux-musl) sha256=93128448e61a9383a30baef041bf1f5817e22f297a1d400521e90294445069a8
+  ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pry (0.16.0) sha256=d76c69065698ed1f85e717bd33d7942c38a50868f6b0673c636192b3d1b6054e
   pry-byebug (3.12.0) sha256=594e094ae8a8390a7ad4c7b36ae36e13304ed02664c67417d108dc5f7213d1b7

--- a/rack-security-middleware.gemspec
+++ b/rack-security-middleware.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'drb'
   s.add_development_dependency 'logger'
   s.add_development_dependency 'mutex_m'
+  s.add_development_dependency 'ostruct'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rack-test', "~> 1.0"
   s.add_development_dependency 'rake', "~> 12.3"


### PR DESCRIPTION
## Summary
- `ostruct` was removed from Ruby's default gems in Ruby 4.0.0, causing a warning when `rake 12.3.3` tries to load it during release CI
- Adds `ostruct` as an explicit development dependency in the gemspec

## Test plan
- [ ] CI passes without the `ostruct` warning on Ruby 4.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)