### PR TITLE
Add Rakefile for gem release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec


### PR DESCRIPTION
## Summary
- Adds a `Rakefile` with `bundler/gem_tasks` so that `bundle exec rake release` works
- The release workflow (`rubygems/release-gem`) requires this file to exist
- Also wires up RSpec as the default rake task

## Test plan
- [ ] Verify `bundle exec rake release` no longer errors with "No Rakefile found"
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)