### PR TITLE
Update rspec and relax rake version constraint for Ruby 4.0 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,18 +101,19 @@ GEM
     rake (12.3.3)
     reline (0.6.3)
       io-console (~> 0.5)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.7)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.2)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.3)
-      rspec-support (~> 3.1.0)
-    rspec-support (3.1.2)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
     securerandom (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -141,8 +142,8 @@ DEPENDENCIES
   pry-byebug
   rack-security-middleware!
   rack-test (~> 1.0)
-  rake (~> 12.3)
-  rspec (~> 3.1.0)
+  rake (>= 12.3)
+  rspec (~> 3.13)
 
 CHECKSUMS
   actionpack (8.1.3) sha256=af998cae4d47c5d581a2cc363b5c77eb718b7c4b45748d81b1887b25621c29a3
@@ -188,11 +189,11 @@ CHECKSUMS
   rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
   rake (12.3.3) sha256=f7694adb4fe638da35452300cee6c545e9c377a0e3190018ac04d590b3c26ab3
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
-  rspec (3.1.0) sha256=a8cfd7ac8416089e3fbf470402760b2d913904ea27d5b3b520b89ac668defee5
-  rspec-core (3.1.7) sha256=89e1aed9b8b1c22d4bc0cbed25e163c10075731df87e2ea9736f1863e9e66a05
-  rspec-expectations (3.1.2) sha256=f0db34c6b7f351031880e08e59c8902f0f037b0e0f7e52345b978667b9190d55
-  rspec-mocks (3.1.3) sha256=f9d76c70a9c38171cdce7a64b871739cf73ec8647d6b70adfe44453a072fb33f
-  rspec-support (3.1.2) sha256=2b5fc899bb71019b7ed956105e8492c90f077641309d9c7c0e09669a72dac693
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6

--- a/rack-security-middleware.gemspec
+++ b/rack-security-middleware.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'ostruct'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rack-test', "~> 1.0"
-  s.add_development_dependency 'rake', "~> 12.3"
-  s.add_development_dependency 'rspec', '~> 3.1.0'
+  s.add_development_dependency 'rake', ">= 12.3"
+  s.add_development_dependency 'rspec', '~> 3.13'
 end


### PR DESCRIPTION
## Summary
- **rspec**: `~> 3.1.0` → `~> 3.13` — rspec-core 3.1.7 calls `Rake::Application#last_comment` which was removed in newer Rake, causing `bundle exec rake release` to fail on Ruby 4.0
- **rake**: `~> 12.3` → `>= 12.3` — relaxed to allow newer Rake versions

## Test plan
- [x] `bundle exec rake release --dry-run` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)